### PR TITLE
Drop the overridden relative_uri() method.

### DIFF
--- a/src/sphinx_rst_builder/_builder.py
+++ b/src/sphinx_rst_builder/_builder.py
@@ -16,32 +16,6 @@ from sphinx.util.osutil import ensuredir, os_path, SEP
 from ._writer import RstWriter
 
 
-# Clone of relative_uri() sphinx.util.osutil, with bug-fixes
-# since the original code had a few errors.
-# This was fixed in Sphinx 1.2b.
-def relative_uri(base, to):
-    """Return a relative URL from ``base`` to ``to``."""
-    if to.startswith(SEP):
-        return to
-    b2 = base.split(SEP)
-    t2 = to.split(SEP)
-    # remove common segments (except the last segment)
-    for x, y in zip(b2[:-1], t2[:-1]):
-        if x != y:
-            break
-        b2.pop(0)
-        t2.pop(0)
-    if b2 == t2:
-        # Special case: relative_uri('f/index.html','f/index.html')
-        # returns '', not 'index.html'
-        return ''
-    if len(b2) == 1 and t2 == ['']:
-        # Special case: relative_uri('f/index.html','f/') should
-        # return './', not ''
-        return '.' + SEP
-    return ('..' + SEP) * (len(b2)-1) + SEP.join(t2)
-
-
 class RstBuilder(Builder):
     name = 'rst'
     format = 'rst'
@@ -103,15 +77,6 @@ class RstBuilder(Builder):
 
     def get_target_uri(self, docname, typ=None):
         return self.link_transform(docname)
-
-    def get_relative_uri(self, from_, to, typ=None):
-        """
-        Return a relative URI between two source filenames.
-        """
-        # This is slightly different from Builder.get_relative_uri,
-        # as it contains a small bug (which was fixed in Sphinx 1.2).
-        return relative_uri(self.get_target_uri(from_),
-                            self.get_target_uri(to, typ))
 
     def prepare_writing(self, docnames):
         self.writer = RstWriter(self)


### PR DESCRIPTION
relative_uri() was cloned because the original method from
sphinx.util.osutil had a bug, fixed in Sphinx 1.2b which is from
2013.

I'd say it's safe to remove it.