### PR TITLE
Correct an import

### DIFF
--- a/src/sphinx_rst_builder/_writer.py
+++ b/src/sphinx_rst_builder/_writer.py
@@ -16,7 +16,8 @@ import logging
 from docutils import nodes, writers
 
 from sphinx import addnodes
-from sphinx.locale import admonitionlabels, versionlabels, _
+from sphinx.locale import admonitionlabels, _
+from sphinx.domains.changeset import versionlabels
 from sphinx.writers.text import TextTranslator, MAXWIDTH, STDINDENT
 
 


### PR DESCRIPTION
versionlabels moved in Sphinx at some point.

Fixes this error:
```
# Sphinx version: 3.2.1
# Python version: 3.8.3 (CPython)
# Docutils version: 0.16 release
# Jinja2 version: 2.11.2
# Last messages:
#   looking for now-outdated files...
#   none found
#   pickling environment...
#   done
#   checking consistency...
#   done
#   preparing documents...
#   done
#   writing output... [  4%] api
#   writing output... [  8%] api_coverage
# Loaded extensions:
#   sphinx.ext.mathjax (3.2.1) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx/ext/mathjax.py
#   sphinxcontrib.applehelp (1.0.2) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinxcontrib/applehelp/__init__.py
#   sphinxcontrib.devhelp (1.0.2) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinxcontrib/devhelp/__init__.py
#   sphinxcontrib.htmlhelp (1.0.3) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinxcontrib/htmlhelp/__init__.py
#   sphinxcontrib.serializinghtml (1.1.4) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinxcontrib/serializinghtml/__init__.py
#   sphinxcontrib.qthelp (1.0.3) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinxcontrib/qthelp/__init__.py
#   alabaster (0.7.12) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/alabaster/__init__.py
#   sphinx.ext.autodoc.type_comment (3.2.1) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx/ext/autodoc/type_comment.py
#   sphinx.ext.autodoc (3.2.1) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx/ext/autodoc/__init__.py
#   sphinx.ext.todo (3.2.1) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx/ext/todo.py
#   sphinx.ext.ifconfig (3.2.1) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx/ext/ifconfig.py
#   sphinxcontrib.spelling (5.4.0) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinxcontrib/spelling/__init__.py
#   sphinx.ext.intersphinx (3.2.1) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx/ext/intersphinx.py
#   sphinx_rst_builder (unknown version) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx_rst_builder/__init__.py
#   sphinx.ext.extlinks (3.2.1) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx/ext/extlinks.py
#   sphinx.ext.napoleon (3.2.1) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx/ext/napoleon/__init__.py
#   sphinx_tabs.tabs (unknown version) from /Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx_tabs/tabs.py
Traceback (most recent call last):
  File "/Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx/cmd/build.py", line 280, in build_main
    app.build(args.force_all, filenames)
  File "/Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx/application.py", line 342, in build
    self.builder.build_all()
  File "/Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 260, in build_all
    self.build(None, summary=__('all source files'), method='all')
  File "/Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 361, in build
    self.write(docnames, list(updated_docnames), method)
  File "/Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 535, in write
    self._write_serial(sorted(docnames))
  File "/Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 545, in _write_serial
    self.write_doc(docname, doctree)
  File "/Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx_rst_builder/_builder.py", line 90, in write_doc
    self.writer.write(doctree, destination)
  File "/Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/docutils/writers/__init__.py", line 78, in write
    self.translate()
  File "/Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx_rst_builder/_writer.py", line 39, in translate
    self.document.walkabout(visitor)
  File "/Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/docutils/nodes.py", line 214, in walkabout
    if child.walkabout(visitor):
  File "/Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/docutils/nodes.py", line 214, in walkabout
    if child.walkabout(visitor):
  File "/Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/docutils/nodes.py", line 214, in walkabout
    if child.walkabout(visitor):
  [Previous line repeated 3 more times]
  File "/Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/docutils/nodes.py", line 206, in walkabout
    visitor.dispatch_visit(self)
  File "/Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx/util/docutils.py", line 468, in dispatch_visit
    method(node)
  File "/Users/ned/coverage/trunk/.tox/doc/lib/python3.8/site-packages/sphinx_rst_builder/_writer.py", line 610, in visit_versionmodified
    self.add_text(versionlabels[node['type']] % node['version'] + ': ')
KeyError: 'versionadded'
```